### PR TITLE
More efficient subtitle download

### DIFF
--- a/crunchyroll/subtitle.go
+++ b/crunchyroll/subtitle.go
@@ -2,100 +2,34 @@ package crunchyroll /* import "s32x.com/anirip/crunchyroll" */
 
 import (
 	"bytes"
-	"compress/zlib"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/sha1"
-	"encoding/base64"
-	"encoding/xml"
-	"fmt"
-	"io"
+	"encoding/json"
+	"errors"
 	"io/ioutil"
-	"math"
-	"net/url"
 	"os"
-	"strconv"
 	"strings"
 
 	"s32x.com/anirip/common"
 )
 
-type SubListResults struct {
-	Subtitles []Subtitle `xml:"subtitle"`
+// Note from turtle: I haven't found a good use for the streams yet but I'll keep looking into it
+type streamStruct struct {
+	Format 		string `json:"format"`
+	AudioLang 	string `json:"audio_lang"`
+	SubLang 	string `json:"hardsub_lang"`
+	urlThingy 	string `json:"url"`
+	Resolution 	string `json:"resolution"`
 }
 
-type Subtitle struct {
-	ID      int     `xml:"id,attr"`
-	Link    string  `xml:"link,attr"`
-	Title   string  `xml:"title,attr"`
-	Default int     `xml:"default,attr"`
-	Delay   float64 `xml:"delay,attr"`
-	Iv      string  `xml:"iv"`
-	Data    string  `xml:"data"`
+type subtitleStruct struct {
+	Language 	string `json:"language"`
+	DownloadURL string `json:"url"`
+	Title 		string `json:"title"`
+	Format 		string `json:"format"`
 }
 
-type SubtitleScript struct {
-	ID        int            `xml:"id,attr"`
-	Title     string         `xml:"title,attr"`
-	PlayResX  int            `xml:"play_res_x,attr"`
-	PlayResY  int            `xml:"play_res_y,attr"`
-	LangCode  string         `xml:"lang_code,attr"`
-	Lang      string         `xml:"lang_string,attr"`
-	Created   string         `xml:"created,attr"`
-	Progress  string         `xml:"progress_string,attr"`
-	Status    string         `xml:"status_string,attr"`
-	WrapStyle int            `xml:"wrap_style,attr"`
-	Styles    []ScriptStyles `xml:"styles"`
-	Events    []ScriptEvents `xml:"events"`
-}
-
-type ScriptStyles struct {
-	Styles []Style `xml:"style"`
-}
-
-type Style struct {
-	ID             int    		`xml:"id,attr"`
-	Name           string 		`xml:"name,attr"`
-	FontName       string 		`xml:"font_name,attr"`
-	FontSize       int    		`xml:"font_size,attr"`
-	PrimaryColor   string 		`xml:"primary_colour,attr"`
-	SecondaryColor string 		`xml:"secondary_colour,attr"`
-	OutlineColor   string 		`xml:"outline_colour,attr"`
-	BackColor      string 		`xml:"back_colour,attr"`
-	Bold           int    		`xml:"bold,attr"`
-	Italic         int    		`xml:"italic,attr"`
-	Underline      int    		`xml:"underline,attr"`
-	Strikeout      int    		`xml:"strikeout,attr"`
-	ScaleX         int    		`xml:"scale_x,attr"`
-	ScaleY         int    		`xml:"scale_y,attr"`
-	Spacing        int    		`xml:"spacing,attr"`
-	Angle          float32    	`xml:"angle,attr"`
-	BorderStyle    int    		`xml:"border_style,attr"`
-	Outline        int    		`xml:"outline,attr"`
-	Shadow         int    		`xml:"shadow,attr"`
-	Alignment      int    		`xml:"alignment,attr"`
-	MarginLeft     string 		`xml:"margin_l,attr"`
-	MarginRight    string 		`xml:"margin_r,attr"`
-	MarginVert     string 		`xml:"margin_v,attr"`
-	Encoding       int    		`xml:"encoding,attr"`
-}
-
-type ScriptEvents struct {
-	Events []Event `xml:"event"`
-}
-
-type Event struct {
-	Event       []ScriptEvents `xml:"events"`
-	ID          int            `xml:"id,attr"`
-	Start       string         `xml:"start,attr"`
-	End         string         `xml:"end,attr"`
-	Style       string         `xml:"style,attr"`
-	Name        string         `xml:"name,attr"`
-	MarginLeft  string         `xml:"margin_l,attr"`
-	MarginRight string         `xml:"margin_r,attr"`
-	MarginVert  string         `xml:"margin_v,attr"`
-	Effect      string         `xml:"effect,attr"`
-	Text        string         `xml:"text,attr"`
+type configStruct struct {
+	Streams 	[]streamStruct `json:"streams"`
+	Subtitles 	[]subtitleStruct `json:"subtitles"`
 }
 
 // DownloadSubtitles entirely downloads subtitles to our temp directory
@@ -103,259 +37,60 @@ func (episode *Episode) DownloadSubtitles(client *common.HTTPClient, language st
 	// Remove stale temp file to avoid conflicts in func
 	os.Remove(tempDir + string(os.PathSeparator) + "subtitles.episode.ass")
 
-	// Populates the subtitle info for the episode
-	subtitles := new(Subtitle)
-	subLang, err := episode.getSubtitleInfo(client, subtitles, language)
+	// Subtitle language (The only two I know fo are enUS and jaJP)
+	subLang := "enUS"
+
+	// Fetch html page for the episode
+	var body []byte
+	if res, err := client.Get(episode.URL, nil); err == nil {
+		defer res.Body.Close()
+		if body, err = ioutil.ReadAll(res.Body); err != nil {
+			return "", err
+		}
+	} else {
+		return "", err
+	}
+
+	// Find the vilos config table and split the area after it. 
+	// Then, trim away the "vilos.config.media = " to produce a json table in string form
+	stringBody := string(body)
+	mediaConfigIndex := strings.Index(stringBody, "vilos.config.media")
+	newResult := strings.SplitAfter(stringBody[mediaConfigIndex:], "}]}")
+	jsonReady := strings.TrimPrefix(newResult[0], "vilos.config.media = ")
+
+	// Parse json string to configStruct
+	var subStruct configStruct
+	if err := json.Unmarshal([]byte(jsonReady), &subStruct); err != nil {
+		return "", err
+	}
+
+	// Verify that there are actually subtitles
+	if len(subStruct.Subtitles) == 0 {
+		return "", errors.New("No subtitle files found(?)")
+	}
+
+	// Determine the best subtitle (I know it currently defaults to enUS but it can be fixed later)
+	chosenSubtitle := subStruct.Subtitles[0]
+	for _, sub := range subStruct.Subtitles {
+		if sub.Language == subLang {
+			chosenSubtitle = sub
+			break
+		}
+	}
+
+	// Fetch the download page for the chosen subtitle (the page that's returned is the decrypted subtitles in ass format)
+	subResp, err := client.Get(chosenSubtitle.DownloadURL, nil)
 	if err != nil {
-		return "", common.NewError("Failed to retrieve subtitle manifest", err)
-	}
-
-	// If we get back a subtitle that was nil (no ID), there are no subs available
-	if episode.SubtitleID == 0 {
-		return "", nil
-	}
-
-	// Places the new subtitle object with JUST INFO into the episode and gets the sub data
-	if err = episode.getSubtitleData(client, subtitles); err != nil {
 		return "", err
 	}
 
-	// Dumps our final subtitle string into an ass file for merging later on
-	if err = episode.dumpSubtitleASS(subtitles, tempDir); err != nil {
+	// Read the subtitles and output them to the subtitles.episode.ass file in the temp directory
+	defer subResp.Body.Close()
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(subResp.Body)
+
+	if err := ioutil.WriteFile(tempDir + string(os.PathSeparator) + "subtitles.episode.ass", buf.Bytes(), 0777); err != nil {
 		return "", err
 	}
-
-	// Defaulting to english for now...
 	return subLang, nil
-}
-
-func (episode *Episode) getSubtitleInfo(client *common.HTTPClient, subtitles *Subtitle, language string) (string, error) {
-	// Querystring to ask for the subtitles info
-	queryString := url.Values{
-		"req":                  {"RpcApiSubtitle_GetListing"},
-		"media_id":             {strconv.Itoa(episode.ID)},
-		"video_format":         {getMapping(episode.Quality, formats)},
-		"video_encode_quality": {getMapping(episode.Quality, qualities)},
-	}.Encode()
-
-	// Formdata to indicate the source page
-	reqBody := bytes.NewBufferString(url.Values{
-		"current_page": {episode.URL},
-	}.Encode())
-
-	// Performs the HTTP Request that will get the XML
-	resp, err := client.Post("http://www.crunchyroll.com/xml/?"+queryString, nil, reqBody)
-	if err != nil {
-		return "", err
-	}
-
-	var subListResults SubListResults
-	if err := xml.NewDecoder(resp.Body).Decode(&subListResults); err != nil {
-		return "", err
-	}
-
-	// Finds the subtitle ID of the language we want
-	for i := 0; i < len(subListResults.Subtitles); i++ {
-		if strings.Contains(subListResults.Subtitles[i].Title, language) {
-			subtitles = &subListResults.Subtitles[i]
-			episode.SubtitleID = subtitles.ID
-			return "eng", nil
-		}
-	}
-
-	// If we cant find the requested language default to English
-	for i := 0; i < len(subListResults.Subtitles); i++ {
-		if strings.Contains(subListResults.Subtitles[i].Title, "English") {
-			subtitles = &subListResults.Subtitles[i]
-			episode.SubtitleID = subtitles.ID
-			return "eng", nil
-		}
-	}
-
-	// Again, if there are no subs found after a succesfull parse, they are either hardcoded or dubbed
-	return "", nil
-}
-
-// Assigns the subtitle to the passed episode and attempts to get the xml subs for this episode
-func (episode *Episode) getSubtitleData(client *common.HTTPClient, subtitles *Subtitle) error {
-	// Querystring to ask for the subtitles data
-	queryString := url.Values{
-		"req":                {"RpcApiSubtitle_GetXml"},
-		"subtitle_script_id": {strconv.Itoa(episode.SubtitleID)},
-	}.Encode()
-
-	// Formdata to indicate the source page
-	body := bytes.NewBufferString(url.Values{
-		"current_page": {episode.URL},
-	}.Encode())
-
-	// Performs the HTTP Request that will get the XML
-	// client.Header.Add("host", "www.crunchyroll.com")
-	// client.Header.Add("origin", "http://static.ak.crunchyroll.com")
-	// client.Header.Add("content-type", "application/x-www-form-urlencoded")
-	// client.Header.Add("referer", "http://static.ak.crunchyroll.com/versioned_assets/StandardVideoPlayer.fb2c7182.swf")
-	// client.Header.Add("x-requested-with", "ShockwaveFlash/19.0.0.245")
-	resp, err := client.Post("http://www.crunchyroll.com/xml/?"+queryString, nil, body)
-	if err != nil {
-		return err
-	}
-	return xml.NewDecoder(resp.Body).Decode(&subtitles)
-}
-
-// Dumps the crunchyroll subtitles to file to be muxed into MKV
-func (episode *Episode) dumpSubtitleASS(subtitles *Subtitle, tempDir string) error {
-	// Attempts to decrypt the compressed subtitles we recieved
-	decryptedSubtitles, err := decryptSubtitles(subtitles)
-	if err != nil {
-		return err
-	}
-
-	// Attempts to format the subtitles for ASS
-	formattedSubtitles, err := formatSubtitles(decryptedSubtitles)
-	if err != nil {
-		return err
-	}
-
-	// Writes the ASS subtitles to a file in our temp folder (with utf-8-sig encoding)
-	subtitlesBytes := append([]byte{0xef, 0xbb, 0xbf}, []byte(formattedSubtitles)...)
-	err = ioutil.WriteFile(tempDir+string(os.PathSeparator)+"subtitles.episode.ass", subtitlesBytes, 0777)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// Decrypts the titles
-func decryptSubtitles(subtitle *Subtitle) (string, error) {
-	// Generates the key that will be used to decrypt our subtitles
-	key := generateKey(subtitle.ID)
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return "", err
-	}
-
-	// Gets the bytes of both our iv and subtitle data
-	iv, err := base64.StdEncoding.DecodeString(subtitle.Iv)
-	if err != nil {
-		return "", err
-	}
-	data, err := base64.StdEncoding.DecodeString(subtitle.Data)
-	if err != nil {
-		return "", err
-	}
-
-	// Decrypts our subtitles back into our data byte array
-	mode := cipher.NewCBCDecrypter(block, iv)
-	mode.CryptBlocks(data, data)
-
-	// Decompresses the subtitles which we've decrypted
-	reader := bytes.NewReader(data)
-	var subOutput bytes.Buffer
-	zlibReader, err := zlib.NewReader(reader)
-	if err != nil {
-		return "", err
-	}
-	io.Copy(&subOutput, zlibReader)
-	zlibReader.Close()
-
-	// Returns the string output of the reader (subtitles string)
-	return subOutput.String(), nil
-}
-
-func formatSubtitles(subString string) (string, error) {
-	subScript := SubtitleScript{}
-
-	// Parses the xml into our results object
-	err := xml.Unmarshal([]byte(subString), &subScript)
-	if err != nil {
-		return "", err
-	}
-
-	// Discarding language for now in order to set to default playback subtitle (subScript.Title)
-	header := "[Script Info]\nTitle: Default Aegisub file\nScriptType: v4.00+\nWrapStyle: " + strconv.Itoa(subScript.WrapStyle) + "\nPlayResX: 656\nPlayResY: 368\n\n"
-	styles := "[V4+ Styles]\nFormat: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\n"
-	events := "\n[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
-
-	styleArray := subScript.Styles[0].Styles
-	eventArray := subScript.Events[0].Events
-
-	for _, style := range styleArray {
-		styles = styles + "Style: " +
-			style.Name + "," +
-			style.FontName + "," +
-			strconv.Itoa(style.FontSize) + "," +
-			style.PrimaryColor + "," +
-			style.SecondaryColor + "," +
-			style.OutlineColor + "," +
-			style.BackColor + "," +
-			strconv.Itoa(style.Bold) + "," +
-			strconv.Itoa(style.Italic) + "," +
-			strconv.Itoa(style.Underline) + "," +
-			strconv.Itoa(style.Strikeout) + "," +
-			strconv.Itoa(style.ScaleX) + "," +
-			strconv.Itoa(style.ScaleY) + "," +
-			strconv.Itoa(style.Spacing) + "," +
-			fmt.Sprintf("%f", style.Angle) + "," +
-			strconv.Itoa(style.BorderStyle) + "," +
-			strconv.Itoa(style.Outline) + "," +
-			strconv.Itoa(style.Shadow) + "," +
-			strconv.Itoa(style.Alignment) + "," +
-			style.MarginLeft + "," +
-			style.MarginRight + "," +
-			style.MarginVert + "," +
-			strconv.Itoa(style.Encoding) + "\n"
-	}
-
-	for _, event := range eventArray {
-		events = events + "Dialogue: 0," +
-			event.Start + "," +
-			event.End + "," +
-			event.Style + "," +
-			event.Name + "," +
-			event.MarginLeft + "," +
-			event.MarginRight + "," +
-			event.MarginVert + "," +
-			event.Effect + "," +
-			event.Text + "\n"
-	}
-
-	return header + styles + events, nil
-}
-
-func generateKey(subtitleID int) []byte {
-	// Does some dank maths to calculate the location of waldo
-	eq1 := int(math.Floor((math.Sqrt(6.9) * math.Pow(2, 25)))) ^ subtitleID
-	eq2 := int(math.Floor(math.Sqrt(6.9) * math.Pow(2, 25)))
-	eq3 := uint32((subtitleID ^ eq2) ^ (subtitleID^eq2)>>3 ^ eq1*32)
-
-	// Creates a 160-Bit SHA1 hash
-	hashData := []byte(createString([]int{20, 97, 1, 2}) + fmt.Sprint(eq3))
-	shortHashArray := sha1.Sum(hashData)
-
-	// Transforms shortHashArray into 256bit in case a 256bit key is requested
-	longHashArray := [32]byte{}
-	for i := range shortHashArray {
-		longHashArray[i] = shortHashArray[i]
-	}
-
-	// Finally turns our longhash into a standard byte array for conversion to string
-	finalHashArray := []byte{}
-	for i := range longHashArray {
-		finalHashArray = append(finalHashArray, longHashArray[i])
-	}
-	return finalHashArray
-}
-
-func createString(args []int) string {
-	i := 0
-	argArray := []int{args[2], args[3]}
-	for i < args[0] {
-		argArray = append(argArray, argArray[len(argArray)-1]+argArray[len(argArray)-2])
-		i = i + 1
-	}
-	finalString := ""
-	for _, arg := range argArray[2:] {
-		finalString += string(arg%args[1] + 33)
-	}
-	return finalString
 }


### PR DESCRIPTION
This (appears to be) a more efficient method for downloading subtitles for Crunchyroll episodes. Instead of using the traditional method of grabbing the episode subtitles, decrypting, and then formatting them, this method grabs configuration data on the episode's page and download the raw subtitles.

There are a few things I would like to note:
1) These subtitles are (almost always) downloaded from VRV, not Crunchyroll. I think this results in the subtitle font being slightly different, but I don't really know
2) While I successfully downloaded multiple seasons of shows without and issues using this new method, I only tested it on Windows. It's probably a good idea to test it before considering merging.
3) I also cannot confirm that subtitle languages outside of English and Japanese will work, as I have not tested that thoroughly enough