### PR TITLE
Subtitle merge hotfix

### DIFF
--- a/crunchyroll/subtitle.go
+++ b/crunchyroll/subtitle.go
@@ -40,6 +40,8 @@ func (episode *Episode) DownloadSubtitles(client *common.HTTPClient, language st
 	os.Remove(subOutput)
 
 	// This turns "en-US" into "enUS", which is Crunchyroll's subtitle format
+	// We also need the ISO-639 code for merging the subtitles later on
+	isoCode := strings.Split(language, "-")[0]
 	language = strings.ReplaceAll(language, "-", "")
 
 	// Fetch html page for the episode
@@ -92,5 +94,5 @@ func (episode *Episode) DownloadSubtitles(client *common.HTTPClient, language st
 	if err := ioutil.WriteFile(subOutput, buf.Bytes(), os.ModePerm); err != nil {
 		return "", fmt.Errorf("writing file: %w", err)
 	}
-	return language, nil
+	return isoCode, nil
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Name = "anirip"
-	app.Version = "1.5.2(12/8/2018)"
+	app.Version = "1.5.5(11/30/2019)"
 	app.Author = "Steven Wolfe"
 	app.Email = "steven@swolfe.me"
 	app.Usage = "anirip username password http://www.crunchyroll.com/miss-kobayashis-dragon-maid"
@@ -43,7 +43,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "language, l",
 			Value: "en-US",
-			Usage: "language code for the subtitles (not all are supported) ex: en-US, ja-JP",
+			Usage: "BCP 47 language code for the subtitles (not all are supported) ex: en-US, ja-JP",
 		},
 		cli.StringFlag{
 			Name:  "quality, q",


### PR DESCRIPTION
This addresses #47 which showed that subtitles were being successfully downloaded but the merging process was failing. This is because ffmepg only accepts [ISO-639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) for its metadata. This hotfix converts the BCP 47 language code into an ISO-639, which will fix the problem

Also as a side note, it seems like Crunchyroll implemented a re-captcha system right as I was working on this hotfix (great timing). The login form now requires a `g-recaptcha-response` field. It seems like we're going to need to find a new method to login, but I can't verify this is in place for everyone