### PR TITLE
Subtitle hotfix and quality setting fixes

### DIFF
--- a/crunchyroll/subtitle.go
+++ b/crunchyroll/subtitle.go
@@ -40,6 +40,7 @@ func (episode *Episode) DownloadSubtitles(client *common.HTTPClient, language st
 	os.Remove(subOutput)
 
 	// This turns "en-US" into "enUS", which is Crunchyroll's subtitle format
+	isoCode := strings.Split(language, "-")[0]
 	language = strings.ReplaceAll(language, "-", "")
 
 	// Fetch html page for the episode
@@ -92,5 +93,5 @@ func (episode *Episode) DownloadSubtitles(client *common.HTTPClient, language st
 	if err := ioutil.WriteFile(subOutput, buf.Bytes(), os.ModePerm); err != nil {
 		return "", fmt.Errorf("writing file: %w", err)
 	}
-	return language, nil
+	return isoCode, nil
 }

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "quality, q",
-			Value: "1080",
+			Value: "720",
 			Usage: "quality of video to download ex: 1080, 720, 480, 360, android",
 		},
 	}
@@ -60,7 +60,7 @@ func main() {
 			return nil
 		}
 
-		download(args[2], args[0], args[1], c.String("lang"), c.String("lang"))
+		download(args[2], args[0], args[1], c.String("quality"), c.String("language"))
 		return nil
 	}
 


### PR DESCRIPTION
This should fix a few issues (#47 and #37). First, it fixes the issue where quality and language flags were not actually being used. Second, it fixes is subtitles not showing by default for the video file. This is because VLC (and almost all media players) require a BCP 47 language code (ex "en", "es") in order to display subtitles by default

@theclickman @benjamin238 please comment here with any issues you experience with this PR

Sorry it took so long to create a PR for this, Crunchyroll had recaptcha verification for a few weeks so I couldn't login to test