### PR TITLE
Fix invalid cross-device link error

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -2,6 +2,7 @@ package common /* import "s32x.com/anirip/common" */
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -20,7 +21,29 @@ func Rename(src, dst string, i int) error {
 		if i > 0 {
 			return Rename(src, dst, i-1)
 		}
-		return err
+		return fmt.Errorf("renaming file: %w", err)
+	}
+	return nil
+}
+
+func Move(src, dst string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening source file: %w", err)
+	}
+
+	// Defer executes in bottom-top order, so the file will close before it is removed
+	defer Delete(src)
+	defer source.Close()
+
+	dest, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("creating destination file: %w", err)
+	}
+
+	defer dest.Close()
+	if _, err := io.Copy(dest, source); err != nil {
+		return fmt.Errorf("copying source to destination file: %w", err)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -149,9 +149,9 @@ func download(showURL, user, pass, quality, origsubLang string) {
 			}
 
 			// Moves the episode to the appropriate season sub-directory
-			if err := common.Rename(tempDir+string(os.PathSeparator)+"episode.mkv",
+			if err := common.Move(tempDir+string(os.PathSeparator)+"episode.mkv",
 				show.GetTitle()+string(os.PathSeparator)+seasonMap[season.GetNumber()]+
-					string(os.PathSeparator)+episode.GetFilename()+".mkv", 10); err != nil {
+					string(os.PathSeparator)+episode.GetFilename()+".mkv"); err != nil {
 				log.Error(err)
 			}
 			log.Success("Downloading and merging completed successfully!")


### PR DESCRIPTION
Added a new function `common.Move` to fix the error regarding renaming a file across partitions (#51). `common.Rename` produced errors on systems where the temporary directory was on a different drive than the working directory.

I have not tested this on any *nix systems as I don't have any, so I can only confirm this update works for Windows users. 